### PR TITLE
Fix flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,11 +11,11 @@
     let
       defaultPackage = pkgs: pkgs.callPackage (nixpkgs + "/pkgs/development/tools/parsing/tree-sitter/grammar.nix") { } {
         language = "typst";
-        source = ./.;
+        src = ./.;
         inherit (pkgs.tree-sitter) version;
       };
     in
-    (flake-utils.lib.eachDefaultSystem
+    (let pkgs = import nixpkgs { }; in { defaultPackage = defaultPackage pkgs; }) // (flake-utils.lib.eachDefaultSystem
       (system:
         let pkgs = import nixpkgs { inherit system; }; in
         {
@@ -27,5 +27,5 @@
               tree-sitter
             ];
           };
-        })) // (let pkgs = import nixpkgs { }; in { defaultPackage = defaultPackage pkgs; });
+        }));
 }


### PR DESCRIPTION
`grammar.nix` requires `src` argument, renamed source to src. Changed order of `defaultPackage` definitions, otherwise `defaultPackage` always requires impure flake evaluation.