### PR TITLE
Various code mode fixes and improvements

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -563,10 +563,10 @@ module.exports = grammar({
         // arg ::= (ident ':')? expr
         _argument: $ => choice(
             alias($.expression, $.argument),
-            $.asssigned_argument
+            $.assigned_argument
         ),
 
-        asssigned_argument: $ => seq(
+        assigned_argument: $ => seq(
             field('name', $.identifier),
             optional($._whitespace),
             ':',

--- a/grammar.js
+++ b/grammar.js
@@ -545,7 +545,7 @@ module.exports = grammar({
 
         // func-call ::= expr args
         function_call: $ => prec.left(1, seq(
-            field('name', $.identifier),
+            field('name', choice($.expression, $.identifier)),
             field('arguments', $.arguments),
         )),
 

--- a/grammar.js
+++ b/grammar.js
@@ -390,15 +390,16 @@ module.exports = grammar({
             'let',
             $._whitespace,
             field('name', $.identifier),
-            choice(seq(
+            choice(prec(1, seq(
                 optional(field('parameters', $.parameters)),
                 optional($._whitespace),
                 '=',
                 optional($._whitespace),
                 field('rhs', choice($.expression, $.identifier)),
                 optional($._whitespace),
-            ),
-                ';'
+            )),
+                ';',
+                $._whitespace
             )
         )),
 
@@ -493,6 +494,10 @@ module.exports = grammar({
         )),
 
         // func-expr ::= (params | ident) '=>' expr
+        // TODO: even with high prec, this doesn't work right.
+        // I also tried setting prec.dynamic and it didn't change anything.
+        // minimal example: #y => a + b + c + d + e
+        // will usually be parsed as (y => a + b) + ...
         function_expression: $ => prec.right(PREC.lambda, seq(
             choice(
                 field('name', $.identifier),

--- a/grammar.js
+++ b/grammar.js
@@ -919,15 +919,26 @@ module.exports = grammar({
         // But we can actually consider single math symbols, such as *, as shorthands.
         // for example, $*$ does not actually output an asterisk, it outputs a centered star.
         // TODO: this is non-exhaustive. either make a list of all shorthands, or write a general heuristic.
-        math_shorthand: $ => choice(
-            "+", "*", "-", // note that "/" is NOT a math symbol
-            "=", "!=", "!", ":=", "...",
-            ">", ">=", "<", "<=",
-            "->", "-->", "=>", "==",
-            // these brackets have negative prec() because we want them to be parsed as math_bracket_expr if possible
-            prec(-1, choice("[", "]", "{", "}", "(", ")", "|")),
-            prec(-1, choice(",", ";", ":", "."))
-        ),
+        math_shorthand: $ => {
+
+            const always = [
+                "+", "*", "-", // note that "/" is NOT a math symbol
+                "=", "!=", "!", ":=", "...",
+                ">", ">=", "<", "<=",
+                "->", "-->", "=>", "=="
+            ];
+            const sometimes = [
+                // sometimes parsed as math_bracket_expr
+                "[", "]", "{", "}", "(", ")", "|", 
+                // sometimes parsed as delimiters
+                ",", ";", ":", "."
+            ];
+            return choice(
+                choice(...always),
+                prec(-1, choice(...sometimes)),
+                prec(1, choice(...sometimes.map(c => "\\" + c)))
+            );
+        },
 
         math_binary_operator: $ => choice(
             // TODO:

--- a/grammar.js
+++ b/grammar.js
@@ -165,7 +165,7 @@ module.exports = grammar({
             $.strong,
         )),
 
-        identifier: $ => prec(2, /[_\p{XID_Start}][_\p{XID_Continue}]*/),
+        identifier: $ => prec(2, /[_\p{XID_Start}][_\p{XID_Continue}-]*/),
 
         // this language uses whitespace to SOMETIMES separate tokens
         // thus, we need to be explicit about whitespace use
@@ -386,7 +386,7 @@ module.exports = grammar({
         continue_statement: $ => prec.left('continue'),
 
         // let ident(params)? '=' expr
-        let_declaration: $ => prec.left(1, seq(
+        let_declaration: $ => prec.right(1, seq(
             'let',
             $._whitespace,
             field('name', $.identifier),
@@ -561,6 +561,8 @@ module.exports = grammar({
         // field-access ::= expr '.' ident
         field_access: $ => prec(PREC.field, seq(
             field('value', choice($.expression, $.identifier)),
+            // Note that actually there should be optional whitespce after the dot as well, but it has to not include newlines
+            //optional($._whitespace),
             '.',
             field('field', $.identifier),
         )),
@@ -568,6 +570,7 @@ module.exports = grammar({
         // method-call ::= expr '.' ident args
         method_call: $ => prec.right(PREC.fieldcall, seq(
             field('value', choice($.expression, $.identifier)),
+            //optional($._whitespace),
             '.',
             field('method', $.identifier),
             field('arguments', $.arguments),

--- a/grammar.js
+++ b/grammar.js
@@ -888,14 +888,14 @@ module.exports = grammar({
             $.string_literal,
 
             $.math_alignment,
-            $.math_nobreak,
+            $.math_break,
             
             $.math_binary_operator,
             $.math_bracket_expr,
             
             $.math_function_call,
             $.math_method_call,
-            $.math_field_access
+            $.math_field_access,
             // todo: figure out a correct spec for how code is allowed in math
             //$._code_mode
         ),
@@ -912,7 +912,7 @@ module.exports = grammar({
         math_identifier: $ => prec.right(1, /\p{Letter}[\p{Letter}\p{Number}]+/),
 
         math_alignment: $ => token("&"),
-        math_nobreak: $ => token("\\\n"),
+        math_break: $ => token("\\"),
 
         // math shorthand refers to symbols which are not simply variables.
         // for example, -> is shorthand for an arrow.
@@ -921,12 +921,12 @@ module.exports = grammar({
         // TODO: this is non-exhaustive. either make a list of all shorthands, or write a general heuristic.
         math_shorthand: $ => choice(
             "+", "*", "-", // note that "/" is NOT a math symbol
-            "=", "!=", "!", ":=",
+            "=", "!=", "!", ":=", "...",
             ">", ">=", "<", "<=",
             "->", "-->", "=>", "==",
             // these brackets have negative prec() because we want them to be parsed as math_bracket_expr if possible
             prec(-1, choice("[", "]", "{", "}", "(", ")", "|")),
-            prec(-1, choice(",", ";", ":"))
+            prec(-1, choice(",", ";", ":", "."))
         ),
 
         math_binary_operator: $ => choice(
@@ -994,7 +994,7 @@ module.exports = grammar({
         math_field_access: $ => prec(PREC.field, seq(
             choice($.math_identifier, $.math_field_access),
             '.',
-            $.math_identifier
+            choice($.math_identifier, $.math_letter)
         )),
 
         math_method_call: $ => prec.right(PREC.fieldcall, seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1863,8 +1863,8 @@
       }
     },
     "function_expression": {
-      "type": "PREC",
-      "value": 9,
+      "type": "PREC_RIGHT",
+      "value": 11,
       "content": {
         "type": "SEQ",
         "members": [
@@ -1941,120 +1941,170 @@
       }
     },
     "parameters": {
-      "type": "PREC_LEFT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "("
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
-                      "members": [
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "_whitespace"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        },
-                        {
-                          "type": "SYMBOL",
-                          "name": "line_comment"
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "\n"
-                        },
-                        {
-                          "type": "CHOICE",
-                          "members": [
-                            {
-                              "type": "SYMBOL",
-                              "name": "_whitespace"
-                            },
-                            {
-                              "type": "BLANK"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "type": "CHOICE",
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT",
+                  "content": {
+                    "type": "SEQ",
                     "members": [
                       {
-                        "type": "SYMBOL",
-                        "name": "_whitespace"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SEQ",
+                        "type": "CHOICE",
                         "members": [
                           {
                             "type": "SYMBOL",
-                            "name": "_parameter"
+                            "name": "_whitespace"
                           },
                           {
-                            "type": "REPEAT",
-                            "content": {
+                            "type": "BLANK"
+                          }
+                        ]
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "line_comment"
+                      },
+                      {
+                        "type": "STRING",
+                        "value": "\n"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_whitespace"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_whitespace"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_parameter"
+                        },
+                        {
+                          "type": "REPEAT",
+                          "content": {
+                            "type": "SEQ",
+                            "members": [
+                              {
+                                "type": "STRING",
+                                "value": ","
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SEQ",
+                                    "members": [
+                                      {
+                                        "type": "SYMBOL",
+                                        "name": "_whitespace"
+                                      },
+                                      {
+                                        "type": "REPEAT",
+                                        "content": {
+                                          "type": "ALIAS",
+                                          "content": {
+                                            "type": "PATTERN",
+                                            "value": "\\p{White_Space}*\\/\\/.*"
+                                          },
+                                          "named": true,
+                                          "value": "line_comment"
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "CHOICE",
+                                "members": [
+                                  {
+                                    "type": "SYMBOL",
+                                    "name": "_whitespace"
+                                  },
+                                  {
+                                    "type": "BLANK"
+                                  }
+                                ]
+                              },
+                              {
+                                "type": "SYMBOL",
+                                "name": "_parameter"
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
+                              "type": "STRING",
+                              "value": ","
+                            },
+                            {
+                              "type": "BLANK"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "CHOICE",
+                          "members": [
+                            {
                               "type": "SEQ",
                               "members": [
                                 {
-                                  "type": "STRING",
-                                  "value": ","
+                                  "type": "SYMBOL",
+                                  "name": "_whitespace"
                                 },
                                 {
-                                  "type": "CHOICE",
-                                  "members": [
-                                    {
-                                      "type": "SEQ",
-                                      "members": [
-                                        {
-                                          "type": "SYMBOL",
-                                          "name": "_whitespace"
-                                        },
-                                        {
-                                          "type": "REPEAT",
-                                          "content": {
-                                            "type": "ALIAS",
-                                            "content": {
-                                              "type": "PATTERN",
-                                              "value": "\\p{White_Space}*\\/\\/.*"
-                                            },
-                                            "named": true,
-                                            "value": "line_comment"
-                                          }
-                                        }
-                                      ]
+                                  "type": "REPEAT",
+                                  "content": {
+                                    "type": "ALIAS",
+                                    "content": {
+                                      "type": "PATTERN",
+                                      "value": "\\p{White_Space}*\\/\\/.*"
                                     },
-                                    {
-                                      "type": "BLANK"
-                                    }
-                                  ]
+                                    "named": true,
+                                    "value": "line_comment"
+                                  }
                                 },
                                 {
                                   "type": "CHOICE",
@@ -2067,87 +2117,33 @@
                                       "type": "BLANK"
                                     }
                                   ]
-                                },
-                                {
-                                  "type": "SYMBOL",
-                                  "name": "_parameter"
                                 }
                               ]
+                            },
+                            {
+                              "type": "BLANK"
                             }
-                          },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "STRING",
-                                "value": ","
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          },
-                          {
-                            "type": "CHOICE",
-                            "members": [
-                              {
-                                "type": "SEQ",
-                                "members": [
-                                  {
-                                    "type": "SYMBOL",
-                                    "name": "_whitespace"
-                                  },
-                                  {
-                                    "type": "REPEAT",
-                                    "content": {
-                                      "type": "ALIAS",
-                                      "content": {
-                                        "type": "PATTERN",
-                                        "value": "\\p{White_Space}*\\/\\/.*"
-                                      },
-                                      "named": true,
-                                      "value": "line_comment"
-                                    }
-                                  },
-                                  {
-                                    "type": "CHOICE",
-                                    "members": [
-                                      {
-                                        "type": "SYMBOL",
-                                        "name": "_whitespace"
-                                      },
-                                      {
-                                        "type": "BLANK"
-                                      }
-                                    ]
-                                  }
-                                ]
-                              },
-                              {
-                                "type": "BLANK"
-                              }
-                            ]
-                          }
-                        ]
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": ")"
-          }
-        ]
-      }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
     },
     "_parameter": {
       "type": "SEQ",
@@ -2583,7 +2579,7 @@
     },
     "field_access": {
       "type": "PREC",
-      "value": 1,
+      "value": 8,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2620,8 +2616,8 @@
       }
     },
     "method_call": {
-      "type": "PREC",
-      "value": 2,
+      "type": "PREC_RIGHT",
+      "value": 9,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2666,8 +2662,8 @@
       }
     },
     "function_call": {
-      "type": "PREC_LEFT",
-      "value": 1,
+      "type": "PREC_RIGHT",
+      "value": 10,
       "content": {
         "type": "SEQ",
         "members": [
@@ -2700,7 +2696,7 @@
       }
     },
     "arguments": {
-      "type": "PREC_LEFT",
+      "type": "PREC_RIGHT",
       "value": 0,
       "content": {
         "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1211,86 +1211,94 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "FIELD",
-                        "name": "parameters",
-                        "content": {
-                          "type": "SYMBOL",
-                          "name": "parameters"
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "FIELD",
+                          "name": "parameters",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "parameters"
+                          }
+                        },
+                        {
+                          "type": "BLANK"
                         }
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_whitespace"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "STRING",
-                    "value": "="
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_whitespace"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "FIELD",
-                    "name": "rhs",
-                    "content": {
+                      ]
+                    },
+                    {
                       "type": "CHOICE",
                       "members": [
                         {
                           "type": "SYMBOL",
-                          "name": "expression"
+                          "name": "_whitespace"
                         },
                         {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "="
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
                           "type": "SYMBOL",
-                          "name": "identifier"
+                          "name": "_whitespace"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "FIELD",
+                      "name": "rhs",
+                      "content": {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "expression"
+                          },
+                          {
+                            "type": "SYMBOL",
+                            "name": "identifier"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_whitespace"
+                        },
+                        {
+                          "type": "BLANK"
                         }
                       ]
                     }
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "SYMBOL",
-                        "name": "_whitespace"
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
+                  ]
+                }
               },
               {
                 "type": "STRING",
                 "value": ";"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -66,7 +66,7 @@
       "value": 2,
       "content": {
         "type": "PATTERN",
-        "value": "[_\\p{XID_Start}][_\\p{XID_Continue}]*"
+        "value": "[_\\p{XID_Start}][_\\p{XID_Continue}-]*"
       }
     },
     "_whitespace": {
@@ -1186,7 +1186,7 @@
       }
     },
     "let_declaration": {
-      "type": "PREC_LEFT",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6148,14 +6148,39 @@
         ]
       }
     },
-    "math_array": {
-      "type": "PREC_LEFT",
-      "value": 0,
+    "_math_assigned_argument": {
+      "type": "PREC",
+      "value": 1,
       "content": {
         "type": "SEQ",
         "members": [
           {
-            "type": "ALIAS",
+            "type": "FIELD",
+            "name": "key",
+            "content": {
+              "type": "SYMBOL",
+              "name": "math_identifier"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "FIELD",
+            "name": "value",
             "content": {
               "type": "REPEAT1",
               "content": {
@@ -6179,9 +6204,59 @@
                   }
                 ]
               }
-            },
-            "named": true,
-            "value": "argument"
+            }
+          }
+        ]
+      }
+    },
+    "math_array": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "math_expression"
+                      },
+                      {
+                        "type": "CHOICE",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "_whitespace"
+                          },
+                          {
+                            "type": "BLANK"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "named": true,
+                "value": "argument"
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_math_assigned_argument"
+                },
+                "named": true,
+                "value": "assigned_argument"
+              }
+            ]
           },
           {
             "type": "REPEAT",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5426,68 +5426,73 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "STRING",
-          "value": "+"
-        },
-        {
-          "type": "STRING",
-          "value": "*"
-        },
-        {
-          "type": "STRING",
-          "value": "-"
-        },
-        {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "STRING",
-          "value": "!="
-        },
-        {
-          "type": "STRING",
-          "value": "!"
-        },
-        {
-          "type": "STRING",
-          "value": ":="
-        },
-        {
-          "type": "STRING",
-          "value": "..."
-        },
-        {
-          "type": "STRING",
-          "value": ">"
-        },
-        {
-          "type": "STRING",
-          "value": ">="
-        },
-        {
-          "type": "STRING",
-          "value": "<"
-        },
-        {
-          "type": "STRING",
-          "value": "<="
-        },
-        {
-          "type": "STRING",
-          "value": "->"
-        },
-        {
-          "type": "STRING",
-          "value": "-->"
-        },
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "STRING",
-          "value": "=="
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "+"
+            },
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "STRING",
+              "value": "-"
+            },
+            {
+              "type": "STRING",
+              "value": "="
+            },
+            {
+              "type": "STRING",
+              "value": "!="
+            },
+            {
+              "type": "STRING",
+              "value": "!"
+            },
+            {
+              "type": "STRING",
+              "value": ":="
+            },
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "STRING",
+              "value": ">"
+            },
+            {
+              "type": "STRING",
+              "value": ">="
+            },
+            {
+              "type": "STRING",
+              "value": "<"
+            },
+            {
+              "type": "STRING",
+              "value": "<="
+            },
+            {
+              "type": "STRING",
+              "value": "->"
+            },
+            {
+              "type": "STRING",
+              "value": "-->"
+            },
+            {
+              "type": "STRING",
+              "value": "=>"
+            },
+            {
+              "type": "STRING",
+              "value": "=="
+            }
+          ]
         },
         {
           "type": "PREC",
@@ -5522,16 +5527,7 @@
               {
                 "type": "STRING",
                 "value": "|"
-              }
-            ]
-          }
-        },
-        {
-          "type": "PREC",
-          "value": -1,
-          "content": {
-            "type": "CHOICE",
-            "members": [
+              },
               {
                 "type": "STRING",
                 "value": ","
@@ -5547,6 +5543,59 @@
               {
                 "type": "STRING",
                 "value": "."
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "\\["
+              },
+              {
+                "type": "STRING",
+                "value": "\\]"
+              },
+              {
+                "type": "STRING",
+                "value": "\\{"
+              },
+              {
+                "type": "STRING",
+                "value": "\\}"
+              },
+              {
+                "type": "STRING",
+                "value": "\\("
+              },
+              {
+                "type": "STRING",
+                "value": "\\)"
+              },
+              {
+                "type": "STRING",
+                "value": "\\|"
+              },
+              {
+                "type": "STRING",
+                "value": "\\,"
+              },
+              {
+                "type": "STRING",
+                "value": "\\;"
+              },
+              {
+                "type": "STRING",
+                "value": "\\:"
+              },
+              {
+                "type": "STRING",
+                "value": "\\."
               }
             ]
           }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -829,6 +829,10 @@
         },
         {
           "type": "SYMBOL",
+          "name": "auto"
+        },
+        {
+          "type": "SYMBOL",
           "name": "label"
         }
       ]
@@ -1319,17 +1323,20 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "if_cause"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "_whitespace"
-                  }
-                ]
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "if_clause"
               },
               {
                 "type": "BLANK"
@@ -1339,34 +1346,65 @@
         ]
       }
     },
-    "if_cause": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "PATTERN",
-          "value": "\\p{White_Space}*if\\p{White_Space}+"
-        },
-        {
-          "type": "FIELD",
-          "name": "condition",
-          "content": {
-            "type": "SYMBOL",
-            "name": "expression"
+    "if_clause": {
+      "type": "PREC_LEFT",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "if"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "condition",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "condition",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "parenthesized_expression"
+                    }
+                  }
+                ]
+              }
+            ]
           }
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "_whitespace"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+        ]
+      }
     },
     "show_expression": {
       "type": "SEQ",
@@ -1448,7 +1486,7 @@
       ]
     },
     "if_expression": {
-      "type": "PREC_LEFT",
+      "type": "PREC_RIGHT",
       "value": 1,
       "content": {
         "type": "SEQ",
@@ -1458,25 +1496,98 @@
             "value": "if"
           },
           {
-            "type": "SYMBOL",
-            "name": "_whitespace"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "condition",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "condition",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "parenthesized_expression"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           {
-            "type": "FIELD",
-            "name": "condition",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              ]
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "consequence",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "content_block"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "consequence",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "code_block"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -1489,23 +1600,6 @@
                 "type": "BLANK"
               }
             ]
-          },
-          {
-            "type": "FIELD",
-            "name": "consequence",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "content_block"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "code_block"
-                }
-              ]
-            }
           },
           {
             "type": "CHOICE",
@@ -1530,8 +1624,8 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "PATTERN",
-          "value": "\\p{White_Space}*else"
+          "type": "STRING",
+          "value": "else"
         },
         {
           "type": "CHOICE",
@@ -1549,17 +1643,21 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "code_block"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "content_block"
-                }
-              ]
+              "type": "FIELD",
+              "name": "consequence",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "code_block"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "content_block"
+                  }
+                ]
+              }
             },
             {
               "type": "SYMBOL",
@@ -1580,54 +1678,98 @@
             "value": "while"
           },
           {
-            "type": "SYMBOL",
-            "name": "_whitespace"
-          },
-          {
-            "type": "FIELD",
-            "name": "condition",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "expression"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "identifier"
-                }
-              ]
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "condition",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "condition",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "parenthesized_expression"
+                    }
+                  }
+                ]
+              }
+            ]
           },
           {
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_whitespace"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "content_block"
+                    }
+                  }
+                ]
               },
               {
-                "type": "BLANK"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "body",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "code_block"
+                    }
+                  }
+                ]
               }
             ]
-          },
-          {
-            "type": "FIELD",
-            "name": "body",
-            "content": {
-              "type": "CHOICE",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "code_block"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "content_block"
-                }
-              ]
-            }
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5356,7 +5356,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "math_nobreak"
+          "name": "math_break"
         },
         {
           "type": "SYMBOL",
@@ -5415,11 +5415,11 @@
         "value": "&"
       }
     },
-    "math_nobreak": {
+    "math_break": {
       "type": "TOKEN",
       "content": {
         "type": "STRING",
-        "value": "\\\n"
+        "value": "\\"
       }
     },
     "math_shorthand": {
@@ -5452,6 +5452,10 @@
         {
           "type": "STRING",
           "value": ":="
+        },
+        {
+          "type": "STRING",
+          "value": "..."
         },
         {
           "type": "STRING",
@@ -5539,6 +5543,10 @@
               {
                 "type": "STRING",
                 "value": ":"
+              },
+              {
+                "type": "STRING",
+                "value": "."
               }
             ]
           }
@@ -6014,8 +6022,17 @@
             "value": "."
           },
           {
-            "type": "SYMBOL",
-            "name": "math_identifier"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "math_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "math_letter"
+              }
+            ]
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -32,6 +32,10 @@
           },
           {
             "type": "SYMBOL",
+            "name": "_math_mode"
+          },
+          {
+            "type": "SYMBOL",
             "name": "quote"
           },
           {
@@ -62,12 +66,8 @@
       }
     },
     "identifier": {
-      "type": "PREC",
-      "value": 2,
-      "content": {
-        "type": "PATTERN",
-        "value": "[_\\p{XID_Start}][_\\p{XID_Continue}-]*"
-      }
+      "type": "PATTERN",
+      "value": "[_\\p{XID_Start}][_\\p{XID_Continue}-]*"
     },
     "_whitespace": {
       "type": "PATTERN",
@@ -5277,6 +5277,327 @@
           }
         }
       ]
+    },
+    "_math_mode": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "$"
+        },
+        {
+          "type": "REPEAT1",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "math_expression"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              }
+            ]
+          }
+        },
+        {
+          "type": "STRING",
+          "value": "$"
+        }
+      ]
+    },
+    "math_expression": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "math_letter"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_shorthand"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_binary_operator"
+        }
+      ]
+    },
+    "math_letter": {
+      "type": "PATTERN",
+      "value": "\\p{Letter}"
+    },
+    "math_number": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "int_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        }
+      ]
+    },
+    "math_identifier": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "PATTERN",
+        "value": "\\p{Letter}[\\p{Letter}\\p{Number}]+"
+      }
+    },
+    "math_shorthand": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "+"
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "-"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": ">="
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": "<="
+        },
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "STRING",
+          "value": "-->"
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        },
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "math_binary_operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "superscript"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "subscript"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "fraction"
+        }
+      ]
+    },
+    "superscript": {
+      "type": "PREC_RIGHT",
+      "value": 6,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "math_expression"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "^"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "math_expression"
+          }
+        ]
+      }
+    },
+    "subscript": {
+      "type": "PREC_RIGHT",
+      "value": 6,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "math_expression"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "_"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "math_expression"
+          }
+        ]
+      }
+    },
+    "fraction": {
+      "type": "PREC_LEFT",
+      "value": 5,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "math_expression"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "/"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "math_expression"
+          }
+        ]
+      }
     }
   },
   "extras": [
@@ -5378,7 +5699,8 @@
     "keyword_expression",
     "comment",
     "unary_expression",
-    "binary_expression"
+    "binary_expression",
+    "math_expression"
   ]
 }
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5286,17 +5286,37 @@
           "value": "$"
         },
         {
-          "type": "REPEAT1",
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_whitespace"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "REPEAT",
           "content": {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
                 "type": "SYMBOL",
                 "name": "math_expression"
               },
               {
-                "type": "SYMBOL",
-                "name": "_whitespace"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               }
             ]
           }
@@ -5316,22 +5336,6 @@
         },
         {
           "type": "SYMBOL",
-          "name": "math_number"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "math_identifier"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "math_shorthand"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "string_literal"
-        },
-        {
-          "type": "SYMBOL",
           "name": "math_binary_operator"
         }
       ]
@@ -5339,113 +5343,6 @@
     "math_letter": {
       "type": "PATTERN",
       "value": "\\p{Letter}"
-    },
-    "math_number": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "int_literal"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "float_literal"
-        }
-      ]
-    },
-    "math_identifier": {
-      "type": "PREC_RIGHT",
-      "value": 1,
-      "content": {
-        "type": "PATTERN",
-        "value": "\\p{Letter}[\\p{Letter}\\p{Number}]+"
-      }
-    },
-    "math_shorthand": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "+"
-        },
-        {
-          "type": "STRING",
-          "value": "*"
-        },
-        {
-          "type": "STRING",
-          "value": "-"
-        },
-        {
-          "type": "STRING",
-          "value": ">"
-        },
-        {
-          "type": "STRING",
-          "value": ">="
-        },
-        {
-          "type": "STRING",
-          "value": "<"
-        },
-        {
-          "type": "STRING",
-          "value": "<="
-        },
-        {
-          "type": "STRING",
-          "value": "->"
-        },
-        {
-          "type": "STRING",
-          "value": "-->"
-        },
-        {
-          "type": "STRING",
-          "value": "=>"
-        },
-        {
-          "type": "STRING",
-          "value": "=="
-        },
-        {
-          "type": "STRING",
-          "value": "["
-        },
-        {
-          "type": "STRING",
-          "value": "]"
-        },
-        {
-          "type": "STRING",
-          "value": "{"
-        },
-        {
-          "type": "STRING",
-          "value": "}"
-        },
-        {
-          "type": "STRING",
-          "value": ","
-        },
-        {
-          "type": "PREC",
-          "value": 1,
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "STRING",
-                "value": "("
-              },
-              {
-                "type": "STRING",
-                "value": ")"
-              }
-            ]
-          }
-        }
-      ]
     },
     "math_binary_operator": {
       "type": "CHOICE",
@@ -5595,6 +5492,18 @@
           {
             "type": "SYMBOL",
             "name": "math_expression"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2533,8 +2533,17 @@
             "type": "FIELD",
             "name": "name",
             "content": {
-              "type": "SYMBOL",
-              "name": "identifier"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "identifier"
+                }
+              ]
             }
           },
           {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5352,11 +5352,31 @@
         },
         {
           "type": "SYMBOL",
+          "name": "math_alignment"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_nobreak"
+        },
+        {
+          "type": "SYMBOL",
           "name": "math_binary_operator"
         },
         {
           "type": "SYMBOL",
           "name": "math_bracket_expr"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_function_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_method_call"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_field_access"
         }
       ]
     },
@@ -5388,6 +5408,20 @@
         "value": "\\p{Letter}[\\p{Letter}\\p{Number}]+"
       }
     },
+    "math_alignment": {
+      "type": "TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "&"
+      }
+    },
+    "math_nobreak": {
+      "type": "TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "\\\n"
+      }
+    },
     "math_shorthand": {
       "type": "CHOICE",
       "members": [
@@ -5414,6 +5448,10 @@
         {
           "type": "STRING",
           "value": "!"
+        },
+        {
+          "type": "STRING",
+          "value": ":="
         },
         {
           "type": "STRING",
@@ -5448,18 +5486,6 @@
           "value": "=="
         },
         {
-          "type": "STRING",
-          "value": ","
-        },
-        {
-          "type": "STRING",
-          "value": ":"
-        },
-        {
-          "type": "STRING",
-          "value": ";"
-        },
-        {
           "type": "PREC",
           "value": -1,
           "content": {
@@ -5492,6 +5518,27 @@
               {
                 "type": "STRING",
                 "value": "|"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "STRING",
+                "value": ";"
+              },
+              {
+                "type": "STRING",
+                "value": ":"
               }
             ]
           }
@@ -5942,6 +5989,274 @@
           }
         }
       ]
+    },
+    "math_field_access": {
+      "type": "PREC",
+      "value": 8,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "math_identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "math_field_access"
+              }
+            ]
+          },
+          {
+            "type": "STRING",
+            "value": "."
+          },
+          {
+            "type": "SYMBOL",
+            "name": "math_identifier"
+          }
+        ]
+      }
+    },
+    "math_method_call": {
+      "type": "PREC_RIGHT",
+      "value": 9,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "value",
+            "content": {
+              "type": "SYMBOL",
+              "name": "math_field_access"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "."
+          },
+          {
+            "type": "FIELD",
+            "name": "method",
+            "content": {
+              "type": "SYMBOL",
+              "name": "math_identifier"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "arguments",
+            "content": {
+              "type": "SYMBOL",
+              "name": "math_arguments"
+            }
+          }
+        ]
+      }
+    },
+    "math_function_call": {
+      "type": "PREC_RIGHT",
+      "value": 10,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "name",
+            "content": {
+              "type": "SYMBOL",
+              "name": "math_identifier"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "arguments",
+            "content": {
+              "type": "SYMBOL",
+              "name": "math_arguments"
+            }
+          }
+        ]
+      }
+    },
+    "math_array": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "REPEAT1",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "math_expression"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "named": true,
+            "value": "argument"
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PREC_LEFT",
+              "value": 0,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "REPEAT1",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "SYMBOL",
+                            "name": "math_expression"
+                          },
+                          {
+                            "type": "CHOICE",
+                            "members": [
+                              {
+                                "type": "SYMBOL",
+                                "name": "_whitespace"
+                              },
+                              {
+                                "type": "BLANK"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    "named": true,
+                    "value": "argument"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    "math_arguments": {
+      "type": "PREC_LEFT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "("
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_whitespace"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "math_array"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          },
+          {
+            "type": "REPEAT",
+            "content": {
+              "type": "PREC_LEFT",
+              "value": 0,
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ";"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_whitespace"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "math_array"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "type": "STRING",
+            "value": ")"
+          }
+        ]
+      }
     }
   },
   "extras": [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2790,11 +2790,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "asssigned_argument"
+          "name": "assigned_argument"
         }
       ]
     },
-    "asssigned_argument": {
+    "assigned_argument": {
       "type": "SEQ",
       "members": [
         {

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -32,7 +32,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "_math_mode"
+            "name": "equation"
           },
           {
             "type": "SYMBOL",
@@ -5278,7 +5278,7 @@
         }
       ]
     },
-    "_math_mode": {
+    "equation": {
       "type": "SEQ",
       "members": [
         {
@@ -5336,13 +5336,167 @@
         },
         {
           "type": "SYMBOL",
+          "name": "math_number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_identifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_shorthand"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
+        },
+        {
+          "type": "SYMBOL",
           "name": "math_binary_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "math_bracket_expr"
         }
       ]
     },
     "math_letter": {
-      "type": "PATTERN",
-      "value": "\\p{Letter}"
+      "type": "TOKEN",
+      "content": {
+        "type": "PATTERN",
+        "value": "\\p{Letter}"
+      }
+    },
+    "math_number": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "int_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float_literal"
+        }
+      ]
+    },
+    "math_identifier": {
+      "type": "PREC_RIGHT",
+      "value": 1,
+      "content": {
+        "type": "PATTERN",
+        "value": "\\p{Letter}[\\p{Letter}\\p{Number}]+"
+      }
+    },
+    "math_shorthand": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "+"
+        },
+        {
+          "type": "STRING",
+          "value": "*"
+        },
+        {
+          "type": "STRING",
+          "value": "-"
+        },
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "!="
+        },
+        {
+          "type": "STRING",
+          "value": "!"
+        },
+        {
+          "type": "STRING",
+          "value": ">"
+        },
+        {
+          "type": "STRING",
+          "value": ">="
+        },
+        {
+          "type": "STRING",
+          "value": "<"
+        },
+        {
+          "type": "STRING",
+          "value": "<="
+        },
+        {
+          "type": "STRING",
+          "value": "->"
+        },
+        {
+          "type": "STRING",
+          "value": "-->"
+        },
+        {
+          "type": "STRING",
+          "value": "=>"
+        },
+        {
+          "type": "STRING",
+          "value": "=="
+        },
+        {
+          "type": "STRING",
+          "value": ","
+        },
+        {
+          "type": "STRING",
+          "value": ":"
+        },
+        {
+          "type": "STRING",
+          "value": ";"
+        },
+        {
+          "type": "PREC",
+          "value": -1,
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              },
+              {
+                "type": "STRING",
+                "value": "{"
+              },
+              {
+                "type": "STRING",
+                "value": "}"
+              },
+              {
+                "type": "STRING",
+                "value": "("
+              },
+              {
+                "type": "STRING",
+                "value": ")"
+              },
+              {
+                "type": "STRING",
+                "value": "|"
+              }
+            ]
+          }
+        }
+      ]
     },
     "math_binary_operator": {
       "type": "CHOICE",
@@ -5507,6 +5661,287 @@
           }
         ]
       }
+    },
+    "math_bracket_expr": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "STRING",
+                  "value": "|"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "math_expression"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_whitespace"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "right",
+                    "content": {
+                      "type": "STRING",
+                      "value": "|"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "STRING",
+                  "value": "["
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "math_expression"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_whitespace"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "right",
+                    "content": {
+                      "type": "STRING",
+                      "value": "]"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "STRING",
+                  "value": "{"
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "math_expression"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_whitespace"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "right",
+                    "content": {
+                      "type": "STRING",
+                      "value": "}"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 0,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "STRING",
+                  "value": "("
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_whitespace"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "math_expression"
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "_whitespace"
+                        },
+                        {
+                          "type": "BLANK"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "FIELD",
+                    "name": "right",
+                    "content": {
+                      "type": "STRING",
+                      "value": ")"
+                    }
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ]
     }
   },
   "extras": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2024,6 +2024,50 @@
     "named": false
   },
   {
+    "type": "\\(",
+    "named": false
+  },
+  {
+    "type": "\\)",
+    "named": false
+  },
+  {
+    "type": "\\,",
+    "named": false
+  },
+  {
+    "type": "\\.",
+    "named": false
+  },
+  {
+    "type": "\\:",
+    "named": false
+  },
+  {
+    "type": "\\;",
+    "named": false
+  },
+  {
+    "type": "\\[",
+    "named": false
+  },
+  {
+    "type": "\\]",
+    "named": false
+  },
+  {
+    "type": "\\{",
+    "named": false
+  },
+  {
+    "type": "\\|",
+    "named": false
+  },
+  {
+    "type": "\\}",
+    "named": false
+  },
+  {
     "type": "]",
     "named": false
   },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -210,6 +210,10 @@
         "named": true
       },
       {
+        "type": "math_break",
+        "named": true
+      },
+      {
         "type": "math_field_access",
         "named": true
       },
@@ -227,10 +231,6 @@
       },
       {
         "type": "math_method_call",
-        "named": true
-      },
-      {
-        "type": "math_nobreak",
         "named": true
       },
       {
@@ -1266,6 +1266,10 @@
         {
           "type": "math_identifier",
           "named": true
+        },
+        {
+          "type": "math_letter",
+          "named": true
         }
       ]
     }
@@ -1960,6 +1964,10 @@
     "named": false
   },
   {
+    "type": "...",
+    "named": false
+  },
+  {
     "type": "/",
     "named": false
   },
@@ -2124,7 +2132,7 @@
     "named": true
   },
   {
-    "type": "math_nobreak",
+    "type": "math_break",
     "named": true
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -330,9 +330,19 @@
     "type": "assigned_argument",
     "named": true,
     "fields": {
+      "key": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "math_identifier",
+            "named": true
+          }
+        ]
+      },
       "name": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "identifier",
@@ -341,11 +351,15 @@
         ]
       },
       "value": {
-        "multiple": false,
+        "multiple": true,
         "required": true,
         "types": [
           {
             "type": "expression",
+            "named": true
+          },
+          {
+            "type": "math_expression",
             "named": true
           }
         ]
@@ -1163,6 +1177,10 @@
       "types": [
         {
           "type": "argument",
+          "named": true
+        },
+        {
+          "type": "assigned_argument",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -814,7 +814,7 @@
         "required": true,
         "types": [
           {
-            "type": "identifier",
+            "type": "expression",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -202,7 +202,27 @@
         "named": true
       },
       {
+        "type": "math_bracket_expr",
+        "named": true
+      },
+      {
+        "type": "math_identifier",
+        "named": true
+      },
+      {
         "type": "math_letter",
+        "named": true
+      },
+      {
+        "type": "math_number",
+        "named": true
+      },
+      {
+        "type": "math_shorthand",
+        "named": true
+      },
+      {
+        "type": "string_literal",
         "named": true
       }
     ]
@@ -593,6 +613,10 @@
           "named": true
         },
         {
+          "type": "equation",
+          "named": true
+        },
+        {
           "type": "escape_sequence",
           "named": true
         },
@@ -606,10 +630,6 @@
         },
         {
           "type": "line_break",
-          "named": true
-        },
-        {
-          "type": "math_expression",
           "named": true
         },
         {
@@ -724,6 +744,10 @@
           "named": true
         },
         {
+          "type": "equation",
+          "named": true
+        },
+        {
           "type": "escape_sequence",
           "named": true
         },
@@ -740,10 +764,6 @@
           "named": true
         },
         {
-          "type": "math_expression",
-          "named": true
-        },
-        {
           "type": "paragraph_break",
           "named": true
         },
@@ -757,6 +777,21 @@
         },
         {
           "type": "strong",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "equation",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "math_expression",
           "named": true
         }
       ]
@@ -1092,7 +1127,96 @@
     }
   },
   {
+    "type": "math_bracket_expr",
+    "named": true,
+    "fields": {
+      "left": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "(",
+            "named": false
+          },
+          {
+            "type": "[",
+            "named": false
+          },
+          {
+            "type": "{",
+            "named": false
+          },
+          {
+            "type": "|",
+            "named": false
+          }
+        ]
+      },
+      "right": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": ")",
+            "named": false
+          },
+          {
+            "type": "]",
+            "named": false
+          },
+          {
+            "type": "|",
+            "named": false
+          },
+          {
+            "type": "}",
+            "named": false
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "math_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "math_letter",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "math_number",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "int_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_shorthand",
     "named": true,
     "fields": {}
   },
@@ -1440,6 +1564,10 @@
           "named": true
         },
         {
+          "type": "equation",
+          "named": true
+        },
+        {
           "type": "escape_sequence",
           "named": true
         },
@@ -1453,10 +1581,6 @@
         },
         {
           "type": "line_break",
-          "named": true
-        },
-        {
-          "type": "math_expression",
           "named": true
         },
         {
@@ -1506,6 +1630,10 @@
           "named": true
         },
         {
+          "type": "equation",
+          "named": true
+        },
+        {
           "type": "escape_sequence",
           "named": true
         },
@@ -1519,10 +1647,6 @@
         },
         {
           "type": "line_break",
-          "named": true
-        },
-        {
-          "type": "math_expression",
           "named": true
         },
         {
@@ -1614,6 +1738,10 @@
     "named": false
   },
   {
+    "type": "!",
+    "named": false
+  },
+  {
     "type": "!=",
     "named": false
   },
@@ -1666,7 +1794,15 @@
     "named": false
   },
   {
+    "type": "-->",
+    "named": false
+  },
+  {
     "type": "-=",
+    "named": false
+  },
+  {
+    "type": "->",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -202,23 +202,7 @@
         "named": true
       },
       {
-        "type": "math_identifier",
-        "named": true
-      },
-      {
         "type": "math_letter",
-        "named": true
-      },
-      {
-        "type": "math_number",
-        "named": true
-      },
-      {
-        "type": "math_shorthand",
-        "named": true
-      },
-      {
-        "type": "string_literal",
         "named": true
       }
     ]
@@ -1108,36 +1092,7 @@
     }
   },
   {
-    "type": "math_identifier",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "math_letter",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "math_number",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "float_literal",
-          "named": true
-        },
-        {
-          "type": "int_literal",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "math_shorthand",
     "named": true,
     "fields": {}
   },
@@ -1711,15 +1666,7 @@
     "named": false
   },
   {
-    "type": "-->",
-    "named": false
-  },
-  {
     "type": "-=",
-    "named": false
-  },
-  {
-    "type": "->",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -160,6 +160,10 @@
     "named": true,
     "subtypes": [
       {
+        "type": "auto",
+        "named": true
+      },
+      {
         "type": "boolean_literal",
         "named": true
       },
@@ -662,19 +666,26 @@
   {
     "type": "else_clause",
     "named": true,
-    "fields": {},
+    "fields": {
+      "consequence": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "code_block",
+            "named": true
+          },
+          {
+            "type": "content_block",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
       "multiple": false,
-      "required": true,
+      "required": false,
       "types": [
-        {
-          "type": "code_block",
-          "named": true
-        },
-        {
-          "type": "content_block",
-          "named": true
-        },
         {
           "type": "if_expression",
           "named": true
@@ -863,7 +874,7 @@
     "fields": {}
   },
   {
-    "type": "if_cause",
+    "type": "if_clause",
     "named": true,
     "fields": {
       "condition": {
@@ -1324,7 +1335,7 @@
       "required": false,
       "types": [
         {
-          "type": "if_cause",
+          "type": "if_clause",
           "named": true
         }
       ]
@@ -1629,6 +1640,10 @@
     "named": false
   },
   {
+    "type": "auto",
+    "named": true
+  },
+  {
     "type": "block_comment",
     "named": true
   },
@@ -1646,6 +1661,10 @@
   },
   {
     "type": "deg",
+    "named": false
+  },
+  {
+    "type": "else",
     "named": false
   },
   {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -194,6 +194,36 @@
     ]
   },
   {
+    "type": "math_expression",
+    "named": true,
+    "subtypes": [
+      {
+        "type": "math_binary_operator",
+        "named": true
+      },
+      {
+        "type": "math_identifier",
+        "named": true
+      },
+      {
+        "type": "math_letter",
+        "named": true
+      },
+      {
+        "type": "math_number",
+        "named": true
+      },
+      {
+        "type": "math_shorthand",
+        "named": true
+      },
+      {
+        "type": "string_literal",
+        "named": true
+      }
+    ]
+  },
+  {
     "type": "unary_expression",
     "named": true,
     "subtypes": [
@@ -595,6 +625,10 @@
           "named": true
         },
         {
+          "type": "math_expression",
+          "named": true
+        },
+        {
           "type": "paragraph_break",
           "named": true
         },
@@ -722,6 +756,10 @@
           "named": true
         },
         {
+          "type": "math_expression",
+          "named": true
+        },
+        {
           "type": "paragraph_break",
           "named": true
         },
@@ -807,6 +845,21 @@
     }
   },
   {
+    "type": "fraction",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "math_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "function_call",
     "named": true,
     "fields": {
@@ -867,11 +920,6 @@
         ]
       }
     }
-  },
-  {
-    "type": "identifier",
-    "named": true,
-    "fields": {}
   },
   {
     "type": "if_clause",
@@ -1035,6 +1083,63 @@
         ]
       }
     }
+  },
+  {
+    "type": "math_binary_operator",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "fraction",
+          "named": true
+        },
+        {
+          "type": "subscript",
+          "named": true
+        },
+        {
+          "type": "superscript",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_identifier",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "math_letter",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "math_number",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "int_literal",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_shorthand",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "method_call",
@@ -1396,6 +1501,10 @@
           "named": true
         },
         {
+          "type": "math_expression",
+          "named": true
+        },
+        {
           "type": "paragraph_break",
           "named": true
         },
@@ -1458,6 +1567,10 @@
           "named": true
         },
         {
+          "type": "math_expression",
+          "named": true
+        },
+        {
           "type": "paragraph_break",
           "named": true
         },
@@ -1471,6 +1584,36 @@
         },
         {
           "type": "strong",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "subscript",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "math_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "superscript",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "math_expression",
           "named": true
         }
       ]
@@ -1528,6 +1671,10 @@
     "named": false
   },
   {
+    "type": "$",
+    "named": false
+  },
+  {
     "type": "%",
     "named": false
   },
@@ -1564,7 +1711,15 @@
     "named": false
   },
   {
+    "type": "-->",
+    "named": false
+  },
+  {
     "type": "-=",
+    "named": false
+  },
+  {
+    "type": "->",
     "named": false
   },
   {
@@ -1632,6 +1787,10 @@
     "named": false
   },
   {
+    "type": "^",
+    "named": false
+  },
+  {
     "type": "_",
     "named": false
   },
@@ -1690,6 +1849,10 @@
   {
     "type": "fr",
     "named": false
+  },
+  {
+    "type": "identifier",
+    "named": true
   },
   {
     "type": "if",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -220,7 +220,7 @@
           "named": true
         },
         {
-          "type": "asssigned_argument",
+          "type": "assigned_argument",
           "named": true
         },
         {
@@ -251,6 +251,32 @@
           "named": true
         }
       ]
+    }
+  },
+  {
+    "type": "assigned_argument",
+    "named": true,
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "expression",
+            "named": true
+          }
+        ]
+      }
     }
   },
   {
@@ -316,32 +342,6 @@
         ]
       },
       "right": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "expression",
-            "named": true
-          }
-        ]
-      }
-    }
-  },
-  {
-    "type": "asssigned_argument",
-    "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          }
-        ]
-      },
-      "value": {
         "multiple": false,
         "required": true,
         "types": [

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -198,6 +198,10 @@
     "named": true,
     "subtypes": [
       {
+        "type": "math_alignment",
+        "named": true
+      },
+      {
         "type": "math_binary_operator",
         "named": true
       },
@@ -206,11 +210,27 @@
         "named": true
       },
       {
+        "type": "math_field_access",
+        "named": true
+      },
+      {
+        "type": "math_function_call",
+        "named": true
+      },
+      {
         "type": "math_identifier",
         "named": true
       },
       {
         "type": "math_letter",
+        "named": true
+      },
+      {
+        "type": "math_method_call",
+        "named": true
+      },
+      {
+        "type": "math_nobreak",
         "named": true
       },
       {
@@ -244,6 +264,21 @@
         "named": true
       }
     ]
+  },
+  {
+    "type": "argument",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "math_expression",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "arguments",
@@ -1104,6 +1139,36 @@
     }
   },
   {
+    "type": "math_arguments",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "math_array",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_array",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "argument",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "math_binary_operator",
     "named": true,
     "fields": {},
@@ -1187,6 +1252,51 @@
     }
   },
   {
+    "type": "math_field_access",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "math_field_access",
+          "named": true
+        },
+        {
+          "type": "math_identifier",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "math_function_call",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "math_arguments",
+            "named": true
+          }
+        ]
+      },
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "math_identifier",
+            "named": true
+          }
+        ]
+      }
+    }
+  },
+  {
     "type": "math_identifier",
     "named": true,
     "fields": {}
@@ -1195,6 +1305,42 @@
     "type": "math_letter",
     "named": true,
     "fields": {}
+  },
+  {
+    "type": "math_method_call",
+    "named": true,
+    "fields": {
+      "arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "math_arguments",
+            "named": true
+          }
+        ]
+      },
+      "method": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "math_identifier",
+            "named": true
+          }
+        ]
+      },
+      "value": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "math_field_access",
+            "named": true
+          }
+        ]
+      }
+    }
   },
   {
     "type": "math_number",
@@ -1826,6 +1972,10 @@
     "named": false
   },
   {
+    "type": ":=",
+    "named": false
+  },
+  {
     "type": ";",
     "named": false
   },
@@ -1967,6 +2117,14 @@
   },
   {
     "type": "line_comment",
+    "named": true
+  },
+  {
+    "type": "math_alignment",
+    "named": true
+  },
+  {
+    "type": "math_nobreak",
     "named": true
   },
   {


### PR DESCRIPTION
There are a couple of big pre-existing bugs that I failed to fix:
1. operator precedence for function expressions is wrong. something like ` x => y + z + w` will usually be parsed as `(x => y) + z + w`. I doubt this matters all that much, honestly
2. whitespace should be allowed between objects and properties (ie, `y . len()`). I tried to fix this but ran into scary conflicts.
3. italic and bold, in markdown mode, are super broken. they can currently start in the middle of a word, but can only end where there's whitespace -- the correct behavior is to start/end after/before the beginning/end of a line or whitespace.