### PR TITLE
Include scanner.c in rust binding build

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());


### PR DESCRIPTION
Previously, building the rust binding would fail with the following error, since `scanner.c` was not included in the build:
```
/usr/bin/ld: undefined reference to `tree_sitter_typst_external_scanner_create'
/usr/bin/ld: undefined reference to `tree_sitter_typst_external_scanner_destroy'
/usr/bin/ld: undefined reference to `tree_sitter_typst_external_scanner_scan'
/usr/bin/ld: undefined reference to `tree_sitter_typst_external_scanner_serialize'
/usr/bin/ld: undefined reference to `tree_sitter_typst_external_scanner_deserialize'
```

This PR includes it so that the rust binding builds successfully.