### PR TITLE
Build scanner.c in build.rs

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,11 +13,9 @@ fn main() {
     // If your language uses an external scanner written in C,
     // then include this block of code:
 
-    /*
     let scanner_path = src_dir.join("scanner.c");
     c_config.file(&scanner_path);
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());


### PR DESCRIPTION
This resolves an issue in rust projects that use this grammar as a crate where the linker would encounter missing symbols.